### PR TITLE
feat: Include callable metadata in AI prompts for better context

### DIFF
--- a/src/alphanso/agent/prompts.py
+++ b/src/alphanso/agent/prompts.py
@@ -85,6 +85,21 @@ def build_user_message(state: ConvergenceState) -> str:
             if command:
                 message += f"Command: `{command}`\n"
 
+            # If this is a callable validator, include function metadata
+            callable_meta = result.get("metadata", {}).get("callable")
+            if callable_meta:
+                message += "\n**Callable Information:**\n"
+                message += f"- Function: `{callable_meta.get('name', 'unknown')}`\n"
+                message += f"- Signature: `{callable_meta.get('signature', 'N/A')}`\n"
+                if callable_meta.get("docstring"):
+                    message += f"- Documentation:\n```\n{callable_meta['docstring']}\n```\n"
+                if callable_meta.get("source_file"):
+                    message += f"- Source: `{callable_meta['source_file']}:{callable_meta.get('source_line', '?')}`\n"
+                if callable_meta.get("source_preview"):
+                    message += (
+                        f"- Code Preview:\n```python\n{callable_meta['source_preview']}\n```\n"
+                    )
+
             message += "\n"
 
             # Include stdout (truncated to last N lines)
@@ -108,6 +123,22 @@ def build_user_message(state: ConvergenceState) -> str:
             command = main_script_result.get("command", "")
             if command:
                 message += f"**Command:** `{command}`\n"
+
+            # If this is a callable, include function metadata
+            callable_meta = main_script_result.get("metadata", {}).get("callable")
+            if callable_meta:
+                message += "\n**Callable Information:**\n"
+                message += f"- Function: `{callable_meta.get('name', 'unknown')}`\n"
+                message += f"- Signature: `{callable_meta.get('signature', 'N/A')}`\n"
+                if callable_meta.get("docstring"):
+                    message += f"- Documentation:\n```\n{callable_meta['docstring']}\n```\n"
+                if callable_meta.get("source_file"):
+                    message += f"- Source: `{callable_meta['source_file']}:{callable_meta.get('source_line', '?')}`\n"
+                if callable_meta.get("source_preview"):
+                    message += (
+                        f"- Code Preview:\n```python\n{callable_meta['source_preview']}\n```\n"
+                    )
+                message += "\n"
 
             exit_code = main_script_result.get("exit_code", "N/A")
             message += f"**Exit Code:** {exit_code}\n\n"

--- a/src/alphanso/graph/nodes.py
+++ b/src/alphanso/graph/nodes.py
@@ -295,7 +295,11 @@ async def run_main_script_node(state: ConvergenceState) -> dict[str, Any]:
     logger.info("")
 
     # Run the script (command or callable) with timing
+    callable_metadata = None
     if callable_func:
+        from alphanso.utils.callable import get_callable_metadata
+
+        callable_metadata = get_callable_metadata(callable_func)
         result = await run_callable_async(
             callable_func, timeout=timeout, working_dir=working_dir, state=state
         )
@@ -331,6 +335,7 @@ async def run_main_script_node(state: ConvergenceState) -> dict[str, Any]:
         "stderr": result["stderr"][-2000:],
         "exit_code": result["exit_code"],
         "duration": duration,
+        "metadata": {"callable": callable_metadata} if callable_metadata else {},
     }
 
     logger.debug(f"📤 Exiting run_main_script_node | success={success}")

--- a/src/alphanso/graph/state.py
+++ b/src/alphanso/graph/state.py
@@ -21,6 +21,7 @@ class MainScriptResult(TypedDict):
         stderr: Captured stderr (last N chars, truncated)
         exit_code: Process exit code
         duration: Time taken to execute in seconds
+        metadata: Additional metadata (e.g., callable info: name, signature, docstring)
     """
 
     command: str
@@ -29,6 +30,7 @@ class MainScriptResult(TypedDict):
     stderr: str
     exit_code: int | None
     duration: float
+    metadata: dict[str, Any]
 
 
 class ValidationResult(TypedDict):

--- a/src/alphanso/validators/callable.py
+++ b/src/alphanso/validators/callable.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from typing import Any
 
 from alphanso.graph.state import ValidationResult
-from alphanso.utils.callable import run_callable_async
+from alphanso.utils.callable import get_callable_metadata, run_callable_async
 from alphanso.validators.base import Validator
 
 logger = logging.getLogger(__name__)
@@ -58,6 +58,9 @@ class CallableValidator(Validator):
         """
         logger.info(f"Running callable validator: {self.name}")
 
+        # Get callable metadata for AI context
+        callable_metadata = get_callable_metadata(self.callable)
+
         # Execute callable with timeout and error handling
         result = await run_callable_async(
             self.callable,
@@ -74,5 +77,5 @@ class CallableValidator(Validator):
             exit_code=result["exit_code"],
             duration=result["duration"],
             timestamp=0.0,  # Will be set by Validator.arun()
-            metadata={},
+            metadata={"callable": callable_metadata},
         )


### PR DESCRIPTION
## Summary

When callables (pre-actions, main scripts, or validators) fail, the AI agent now receives comprehensive function metadata to understand exactly what went wrong and how to fix it.

## Problem

Previously, when a callable failed, the AI only saw:
- Error traceback
- Stdout/stderr output
- Function name in the command field

This wasn't enough context to understand:
- What the function was supposed to do
- What parameters it received
- Where the source code is located

## Solution

Added `get_callable_metadata()` to extract and include in AI prompts:
- **Function name & signature**: Shows exact parameters and types
- **Docstring**: Explains the function's purpose and behavior
- **Source location**: File path and line number for investigation
- **Code preview**: First 10 lines of the function for immediate context

## Changes

1. **`utils/callable.py`**:
   - Added `get_callable_metadata()` using Python's `inspect` module
   - Extracts name, signature, docstring, source file, line number, and code preview

2. **`graph/state.py`**:
   - Added `metadata: dict[str, Any]` field to `MainScriptResult`

3. **`graph/nodes.py`**:
   - Updated `run_main_script_node()` to capture callable metadata
   - Stores metadata in `main_script_result["metadata"]["callable"]`

4. **`validators/callable.py`**:
   - Updated `CallableValidator.avalidate()` to include callable metadata
   - Stores in `ValidationResult["metadata"]["callable"]`

5. **`agent/prompts.py`**:
   - Enhanced `build_user_message()` to format callable metadata in prompts
   - Shows function info for both main script and validator failures

## Example AI Prompt Output

When a callable fails, the AI now sees:

```markdown
## Main Script Failed

**Description:** Process data
**Command:** `callable:process_data`

**Callable Information:**
- Function: `process_data`
- Signature: `(working_dir: str | None = None, state: dict[str, Any] | None = None, **kwargs: Any) -> str`
- Documentation:
```
Main task that processes data.

This is the main script that gets retried until it succeeds.
Fails on first call, succeeds on second to demonstrate retry + validators.
```
- Source: `/path/to/demo.py:49`
- Code Preview:
```python
async def process_data(
    working_dir: str | None = None, state: dict[str, Any] | None = None, **kwargs: Any
) -> str:
    """Main task that processes data.

    This is the main script that gets retried until it succeeds.
    Fails on first call, succeeds on second to demonstrate retry + validators.
    """
    global _process_data_calls
    _process_data_calls += 1
```

**Exit Code:** 1

**Error Output:**
```
RuntimeError: Connection timeout while fetching data
```
```

## Benefits

- **Better Fixes**: AI can see function intent from docstring
- **Faster Investigation**: Source location points AI to the right file
- **Context-Aware**: Code preview shows surrounding logic
- **Parameter Clarity**: Signature shows exactly what was passed

## Testing

- All 228 tests pass
- Pre-commit hooks pass
- Tested with callable-demo example showing full metadata in AI prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)