### PR TITLE
Update framework branding to 'The Agentic Convergence Framework'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <h1>Alphanso</h1>
-  <p><strong>AI Assisted Convergence Framework for Automation</strong></p>
+  <p><strong>The Agentic Convergence Framework</strong></p>
 
   <p>
     <a href="#installation">Installation</a> •
@@ -16,7 +16,7 @@
 
 ## Overview
 
-Alphanso is a production-grade Python framework that leverages AI convergence loops to automate complex, iterative problem-solving workflows. Built on [LangGraph](https://github.com/langchain-ai/langgraph) state machine orchestration, it enables autonomous resolution of challenging tasks including dependency upgrades, code refactoring, infrastructure updates, and Kubernetes rebasing.
+Alphanso is a production-grade Python framework that leverages agentic convergence loops to automate complex, iterative problem-solving workflows. Built on [LangGraph](https://github.com/langchain-ai/langgraph) state machine orchestration, it enables autonomous resolution of challenging tasks including dependency upgrades, code refactoring, infrastructure updates, and Kubernetes rebasing.
 
 ## Workflow Architecture
 

--- a/examples/openshift-rebase/README.md
+++ b/examples/openshift-rebase/README.md
@@ -1,3 +1,5 @@
+> **Note**: This is an example use case demonstrating Alphanso - The Agentic Convergence Framework. For an overview of the framework, its architecture, and other use cases, please see the [main README](../../README.md).
+
 # OpenShift Kubernetes Rebase Example
 
 This example demonstrates how Alphanso automates the complex process of rebasing OpenShift's Kubernetes fork against upstream Kubernetes releases.


### PR DESCRIPTION
## Summary

This PR updates the framework branding to better reflect its agentic nature:

- Renames from "AI Assisted Convergence Framework for Automation" to "The Agentic Convergence Framework"
- Updates overview to use "agentic convergence loops" terminology
- Adds contextual note to OpenShift example README with link to main framework documentation

## Rationale

The new name "The Agentic Convergence Framework" more accurately describes the framework's autonomous, agent-driven approach to solving iterative problems. This also helps when sharing specific examples (like OpenShift rebase) - readers will now see a link to the main framework documentation for context.

## Changes

- **README.md**: Updated title and overview with new branding
- **examples/openshift-rebase/README.md**: Added intro note linking to main README

## Test plan

- [x] Verified markdown rendering is correct
- [x] Verified link to main README works from example subdirectory
- [x] Confirmed terminology is consistent across both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)